### PR TITLE
feat: display StructArray values in table

### DIFF
--- a/src/views/query_results.rs
+++ b/src/views/query_results.rs
@@ -478,6 +478,11 @@ impl ArrayExt for dyn Array {
                 let len = value.len();
                 format!("[{}]",  (0..len).map(|i| value.value_to_string(i)).collect::<Vec<_>>().join(", "))
             }
+            DataType::Struct(_) => {
+                let array = as_struct_array(array);
+                let len = array.num_columns();
+                format!("[{}]",  (0..len).map(|i| array.column(i).value_to_string(index)).collect::<Vec<_>>().join(", "))
+            }
             DataType::Dictionary(key_type, _) => {
                 match key_type.as_ref() {
                     DataType::Int8 => {


### PR DESCRIPTION
## Before

All STRUCT column cells would show `Unsupported datatype Struct { ... }`

## After

<img width="1616" alt="image" src="https://github.com/user-attachments/assets/818a7b2f-869f-4a9d-a648-f9005a854da0" />
