### PR TITLE
Support viewing Parquet files larger than 2 GB

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ Checkout the awesome [Leptos](https://github.com/leptos-rs/leptos) framework.
 #### Run locally
 ```bash
 cargo install trunk --locked
-
-trunk serve --release  --no-autoreload
+trunk serve --release --no-autoreload
 ```
 
 #### Run tests

--- a/src/views/web_file_store.rs
+++ b/src/views/web_file_store.rs
@@ -168,12 +168,15 @@ impl WebFileReader {
 
     /// Get a slice of the file
     pub async fn get_range(&self, range: Range<u64>) -> Result<Bytes, String> {
-        logging::log!("Fetching range {:?} from file", range);
-
+        logging::log!(
+            "get_range: [f64] Fetching range {}...{} from file",
+            range.start as f64,
+            range.end as f64
+        );
         // Use the slice method to get only the requested range
         let blob = self
             .file
-            .slice_with_i32_and_i32(range.start as i32, range.end as i32)
+            .slice_with_f64_and_f64(range.start as f64, range.end as f64)
             .map_err(|e| format!("Failed to slice file: {e:?}"))?;
 
         let array_buffer = JsFuture::from(blob.array_buffer()).await.unwrap();


### PR DESCRIPTION
This PR closes #32 by replacing `slice_with_i32_and_i32` with `slice_with_f64_and_f64`.