### PR TITLE
Having human-readble byte-unit without hardcoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ uuid = { version = "1.16.0", features = ["v4", "js"] }
 tokio = { version = "1.45.0", features = ["rt"] }
 gloo-net = "0.6.0"
 getrandom = { version = "0.3", features = ["wasm_js"] }
+byte-unit = "5.1.6"
 
 [profile.release]
 strip = true

--- a/src/components/file_info.rs
+++ b/src/components/file_info.rs
@@ -1,6 +1,7 @@
 use leptos::prelude::*;
 
 use crate::utils::format_rows;
+use byte_unit::{Byte, UnitType};
 
 #[component]
 pub fn FileLevelInfo(metadata_display: crate::parquet_ctx::MetadataDisplay) -> impl IntoView {
@@ -22,39 +23,54 @@ pub fn FileLevelInfo(metadata_display: crate::parquet_ctx::MetadataDisplay) -> i
                 <div class="space-y-1">
                     <span class="text-gray-400 text-xs">"File size"</span>
                     <span class="block">
-                        {format!("{:.2} MB", metadata_display.file_size as f64 / 1_048_576.0)}
+                        {format!(
+                            "{:.2}",
+                            Byte::from_u64(metadata_display.file_size).get_appropriate_unit(UnitType::Binary)
+                        )}
                     </span>
                 </div>
                 <div class="space-y-1">
                     <span class="text-gray-400 text-xs">"Compressed row groups"</span>
                     <span class="block">
-                        {format!("{:.2} MB", metadata_display.compressed_row_group_size as f64 / 1_048_576.0)}
+                        {format!(
+                            "{:.2}",
+                            Byte::from_u64(metadata_display.compressed_row_group_size).get_appropriate_unit(UnitType::Binary)
+                        )}
                     </span>
                 </div>
                 <div class="space-y-1">
                     <span class="text-gray-400 text-xs">"Metadata size"</span>
                     <span class="block">
-                        {format!("{:.2} KB", metadata_display.footer_size as f64 / 1024.0)}
+                        {format!(
+                            "{:.2}",
+                            Byte::from_u64(metadata_display.footer_size).get_appropriate_unit(UnitType::Binary)
+                        )}
                     </span>
                 </div>
                 <div class="space-y-1">
                     <span class="text-gray-400 text-xs">"Metadata in memory size"</span>
                     <span class="block">
-                        {format!("{:.2} KB", metadata_display.metadata_memory_size as f64 / 1024.0)}
+                        {format!(
+                            "{:.2}",
+                            Byte::from_u64(metadata_display.metadata_memory_size).get_appropriate_unit(UnitType::Binary)
+                        )}
                     </span>
                 </div>
                 <div class="space-y-1">
                     <span class="text-gray-400 text-xs">"Bloom filter size"</span>
                     <span class="block">
-                        {format!("{:.2} MB", metadata_display.total_bloom_filter_size as f64 / 1_048_576.0)}
+                        {format!(
+                            "{:.2}",
+                            Byte::from_u64(metadata_display.total_bloom_filter_size).get_appropriate_unit(UnitType::Binary)
+                        )}
                     </span>
                 </div>
                 <div class="space-y-1">
                     <span class="text-gray-400 text-xs">"Uncompressed"</span>
                     <span class="block">
                         {format!(
-                            "{:.2} MB",
-                            metadata_display.uncompressed_size as f64 / 1_048_576.0,
+                            "{:.2}",
+                            Byte::from_u64(metadata_display.uncompressed_size).get_appropriate_unit(UnitType::Binary)
                         )}
                     </span>
                 </div>

--- a/src/components/page_info.rs
+++ b/src/components/page_info.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use byte_unit::{Byte, UnitType};
 use bytes::{Buf, Bytes};
 use leptos::prelude::*;
 use parquet::{
@@ -186,7 +187,7 @@ pub fn PageInfo(
             let mut page_info = Vec::new();
             for page in page_reader.flatten() {
                 let page_type = page.page_type();
-                let page_size = page.buffer().len() as f64 / 1024.0;
+                let page_size = page.buffer().len() as u64;
                 let num_values = page.num_values();
                 page_info.push((page_type, page_size, num_values, page.encoding()));
             }
@@ -225,7 +226,10 @@ pub fn PageInfo(
                                             <div class="grid grid-cols-[1rem_7rem_4rem_4rem_1fr] gap-3 hover:bg-gray-50">
                                                 <span>{format!("{i}")}</span>
                                                 <span>{format!("{page_type:?}")}</span>
-                                                <span>{format!("{} KB", size.round() as i64)}</span>
+                                                <span>{format!(
+                                                    "{:.0}",
+                                                    Byte::from_u64(*size).get_appropriate_unit(UnitType::Binary)
+                                                )}</span>
                                                 <span>{format_rows(*values as u64)}</span>
                                                 <span>{format!("{encoding:?}")}</span>
                                             </div>

--- a/src/parquet_ctx.rs
+++ b/src/parquet_ctx.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use arrow_schema::SchemaRef;
+use byte_unit::{Byte, UnitType};
 use datafusion::execution::object_store::ObjectStoreUrl;
 use object_store::path::Path;
 use parquet::{
@@ -107,12 +108,12 @@ impl std::fmt::Display for MetadataDisplay {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "File Size: {} MB\nCompressed Row Groups: {} MB\nFooter Size: {} KB\nMemory Size: {} KB\nBloom Filter Size: {} KB\nRow Groups: {}\nTotal Rows: {}\nColumns: {}\nFeatures: {}{}{}{}",
-            self.file_size as f64 / 1_048_576.0, // Convert bytes to MB
-            self.compressed_row_group_size as f64 / 1_048_576.0, // Convert bytes to MB
-            self.footer_size as f64 / 1024.0,    // Convert bytes to KB
-            self.metadata_memory_size as f64 / 1024.0, // Convert bytes to KB
-            self.total_bloom_filter_size as f64 / 1024.0, // Convert bytes to KB
+            "File Size: {:.2}\nCompressed Row Groups: {:.2}\nFooter Size: {:.2}\nMemory Size: {:.2}\nBloom Filter Size: {:.2}\nRow Groups: {}\nTotal Rows: {}\nColumns: {}\nFeatures: {}{}{}{}",
+            Byte::from_u64(self.file_size).get_appropriate_unit(UnitType::Binary),
+            Byte::from_u64(self.compressed_row_group_size).get_appropriate_unit(UnitType::Binary),
+            Byte::from_u64(self.footer_size).get_appropriate_unit(UnitType::Binary),
+            Byte::from_u64(self.metadata_memory_size).get_appropriate_unit(UnitType::Binary),
+            Byte::from_u64(self.total_bloom_filter_size).get_appropriate_unit(UnitType::Binary),
             self.row_group_count,
             self.row_count,
             self.columns,

--- a/src/views/schema.rs
+++ b/src/views/schema.rs
@@ -7,6 +7,7 @@ use arrow::datatypes::{Float32Type, Int64Type, UInt64Type};
 use arrow_array::{BooleanArray, Float32Array, RecordBatch, UInt64Array};
 use arrow_array::{StringArray, UInt32Array};
 use arrow_schema::{DataType, Field, Schema};
+use byte_unit::{Byte, UnitType};
 use leptos::prelude::*;
 use std::sync::Arc;
 
@@ -250,13 +251,11 @@ fn calculate_distinct(column_name: &String, table_name: &String) -> LocalResourc
 fn format_u64_size(val: &RecordBatch, (col_idx, row_idx): (usize, usize)) -> AnyView {
     let col = val.column(col_idx).as_primitive::<UInt64Type>();
     let size = col.value(row_idx);
-    if size > 1_048_576 {
-        format!("{:.2} MB", size as f64 / 1_048_576.0).into_any()
-    } else if size > 1024 {
-        format!("{:.2} KB", size as f64 / 1024.0).into_any()
-    } else {
-        format!("{size} B").into_any()
-    }
+    format!(
+        "{:.2}",
+        Byte::from_u64(size).get_appropriate_unit(UnitType::Binary)
+    )
+    .into_any()
 }
 
 fn format_f32_percentage(val: &RecordBatch, (col_idx, row_idx): (usize, usize)) -> AnyView {


### PR DESCRIPTION
This PR closes #34:
- using `byte-unit` for showing the human-readable units
- replacing hardcoded units such as MB/KB with binary units such as MiB/KiB
