### PR TITLE
Allow HTTP authentification

### DIFF
--- a/src/views/parquet_reader.rs
+++ b/src/views/parquet_reader.rs
@@ -376,7 +376,17 @@ pub fn read_from_url(url_str: &str) -> Result<ParquetUnresolved> {
         .unwrap_or("uploaded.parquet")
         .to_string();
 
-    let builder = Http::default().endpoint(&endpoint);
+    let builder = {
+        let mut http_builder = Http::default().endpoint(&endpoint);
+        let username = url.username();
+        if !username.is_empty() {
+            http_builder = http_builder.username(username);
+        }
+        if let Some(password) = url.password() {
+            http_builder = http_builder.password(password);
+        }
+        http_builder
+    };
     let op = Operator::new(builder)?;
     let op = op.finish();
     let object_store = Arc::new(ObjectStoreCache::new(OpendalStore::new(op)));


### PR DESCRIPTION
This PR will allow specifying a HTTP URL with prefixed basic HTTP credentials, such as `http://[username]:[password]@...`.

Unfortunately, in browsers without `--disable-web-security` I'm getting CORS error right now...