### PR TITLE
Fix logical size due to the overflow

### DIFF
--- a/src/views/schema.rs
+++ b/src/views/schema.rs
@@ -42,9 +42,7 @@ fn calculate_arrow_memory_size(metadata: &ParquetMetaData, column_index: usize) 
             // Variable-length data - cannot estimate reliably
             return None;
         }
-        parquet::basic::Type::FIXED_LEN_BYTE_ARRAY => {
-            first_col.column_descr().type_length() as u64
-        }
+        parquet::basic::Type::FIXED_LEN_BYTE_ARRAY => first_col.column_descr().type_length() as u64,
     };
 
     // Estimate Arrow memory: data + validity bitmap + metadata overhead


### PR DESCRIPTION
This is a PR fixing the #55. 

Sorry for the inconvenience caused by this bug. The issue was due to an integer overflow, and this patch addresses that specific cause. Below is the same file for comparison as in the issue:

- Current version running online (without this patch):

<img width="2058" height="564" alt="image" src="https://github.com/user-attachments/assets/7abf9d12-e4fa-4137-9a8c-f3ba120e3cdb" />

- With this patch:

<img width="2214" height="640" alt="image" src="https://github.com/user-attachments/assets/966b293e-2991-4bb0-8f88-bbc3c01168ad" />
