### PR TITLE
Use codec_to_string for compression display

### DIFF
--- a/src/views/metadata.rs
+++ b/src/views/metadata.rs
@@ -10,6 +10,27 @@ use std::sync::Arc;
 
 use crate::utils::format_rows;
 
+/// Mirror `Compression::codec_to_string` from `arrow-rs` so we can keep parity with the
+/// formatting used by upstream metadata printing helpers.
+trait CompressionExt {
+    fn codec_to_string(self) -> &'static str;
+}
+
+impl CompressionExt for Compression {
+    fn codec_to_string(self) -> &'static str {
+        match self {
+            Compression::UNCOMPRESSED => "UNCOMPRESSED",
+            Compression::SNAPPY => "SNAPPY",
+            Compression::GZIP(_) => "GZIP",
+            Compression::LZO => "LZO",
+            Compression::BROTLI(_) => "BROTLI",
+            Compression::LZ4 => "LZ4",
+            Compression::ZSTD(_) => "ZSTD",
+            Compression::LZ4_RAW => "LZ4_RAW",
+        }
+    }
+}
+
 #[component]
 pub fn MetadataView(parquet_reader: Arc<ParquetResolved>) -> impl IntoView {
     let metadata_display = parquet_reader.metadata().clone();
@@ -267,7 +288,7 @@ pub fn ColumnInfo(
                     </div>
                     <div class="space-y-1">
                         <div class="text-gray-500">"CompressionType"</div>
-                        <div>{format!("{:?}", column_info.compression)}</div>
+                        <div>{column_info.compression.codec_to_string()}</div>
                     </div>
                     <div class="space-y-1">
                         <div class="text-gray-500">"Pages"</div>


### PR DESCRIPTION
## Summary
- mirror arrow-rs' `Compression::codec_to_string` helper so we can reuse its compression label formatting
- use the helper when rendering column metadata so the compression type display no longer includes level details

## Testing
- cargo fmt
- cargo check *(fails: `wasm32-unknown-unknown` target not installed in the environment)*
- cargo check --target x86_64-unknown-linux-gnu *(fails: existing Leptos `RenderHtml`/`IntoProperty` trait bound errors in `parquet_reader.rs` and `settings.rs`)*

------
https://chatgpt.com/codex/tasks/task_e_68d2a6dacb1c83328de1802cbd60f1d3