### PR TITLE
Run ci in firefox instead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           nix develop --command bash -c "
             cargo fmt --all -- --check && \
             cargo clippy -- -D warnings && \
-            wasm-pack test --headless --chrome
+            wasm-pack test --headless --firefox
           "
       - name: Set result output
         id: result

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2853,7 +2853,7 @@ dependencies = [
 
 [[package]]
 name = "parquet-viewer"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "arrow",

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ trunk serve --release --no-autoreload
 
 ```bash
 cargo install wasm-pack --locked
-wasm-pack test --headless --chrome
+wasm-pack test --headless --firefox
 ```
 
 #### Build VS Code extension

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1758035966,
-        "narHash": "sha256-qqIJ3yxPiB0ZQTT9//nFGQYn8X/PBoJbofA7hRKZnmE=",
+        "lastModified": 1761907660,
+        "narHash": "sha256-kJ8lIZsiPOmbkJypG+B5sReDXSD1KGu2VEPNqhRa/ew=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8d4ddb19d03c65a36ad8d189d001dc32ffb0306b",
+        "rev": "2fb006b87f04c4d3bdf08cfdbc7fab9c13d94a15",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1758204348,
-        "narHash": "sha256-jkz/NihbcEwy1EHDv/6g0HEqkpyIWCnQ1siGrhHEtFM=",
+        "lastModified": 1762051177,
+        "narHash": "sha256-pESNTx/m3WnrYx+OujBtDP5Bj0/mAyHa4MgEwzkgkLE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "067b3536e55341f579385ce8593cdcc9d022972b",
+        "rev": "08c33e87c4829bbdd42b5af247cf7a19e126369f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -41,8 +41,8 @@
             typescript
             pnpm
             vsce
-            chromedriver
-            chromium
+            geckodriver
+            firefox
             llvmPackages_20.clang
             lld_20
             llvmPackages_20.libcxx


### PR DESCRIPTION
Unblocks #69 

Chrome in CI & NixOS is stupid, it produces nonsense error message on a slight version mismatch between chrome driver and the browser; and this mismatch happens monthly.

Let's move to firefox instead, since it already supports all the features parquet viewer needs